### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Configure Composer
         run: |
           composer config "http-basic.nova.laravel.com" "${{ secrets.NOVA_USERNAME }}" "${{ secrets.NOVA_PASSWORD }}"
-          composer require "laravel/nova:^5.0"
+          # TODO: Bump to ^5.0 once a Nova 5.x licence key is available
+          composer require "laravel/nova:4.33.2"
 
       - name: Install composer dependencies
         uses: ramsey/composer-install@v4

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,13 +16,13 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.4'
           coverage: none
 
       - name: Configure Composer
         run: |
           composer config "http-basic.nova.laravel.com" "${{ secrets.NOVA_USERNAME }}" "${{ secrets.NOVA_PASSWORD }}"
-          composer require "laravel/nova:4.33.2"
+          composer require "laravel/nova:^5.0"
 
       - name: Install composer dependencies
         uses: ramsey/composer-install@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.5, 8.4, 8.3, 8.2]
-        # TODO: Add 13.* once a Nova 5.x licence key is available
-        laravel: [11.*, 12.*]
+        # TODO: Add 12.* and 13.* once a Nova 5.x licence key is available
+        laravel: [11.*]
         stability: [prefer-lowest, prefer-stable]
         exclude:
           - laravel: 11.*
@@ -25,9 +25,6 @@ jobs:
         include:
           - laravel: 11.*
             testbench: 9.*
-            nova: 4.33.1
-          - laravel: 12.*
-            testbench: 10.*
             nova: 4.33.1
           # Nova only officially supports Laravel 12+ on Nova 5.x.
           # Enable these entries once a Nova 5.x licence key is available:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,13 +14,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.5, 8.4, 8.3, 8.2]
-        laravel: [11.*, 12.*, 13.*]
+        # TODO: Add 13.* once a Nova 5.x licence key is available
+        laravel: [11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         exclude:
           - laravel: 11.*
             php: 8.5
-          - laravel: 13.*
-            php: 8.2
+          # - laravel: 13.*
+          #   php: 8.2
         include:
           - laravel: 11.*
             testbench: 9.*
@@ -28,9 +29,14 @@ jobs:
           - laravel: 12.*
             testbench: 10.*
             nova: 4.33.1
-          - laravel: 13.*
-            testbench: 11.*
-            nova: 5.*
+          # Nova only officially supports Laravel 12+ on Nova 5.x.
+          # Enable these entries once a Nova 5.x licence key is available:
+          # - laravel: 12.*
+          #   testbench: 10.*
+          #   nova: 5.*
+          # - laravel: 13.*
+          #   testbench: 11.*
+          #   nova: 5.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - N${{ matrix.nova }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,15 +13,24 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: [11.*, 12.*]
-        nova: [4.33.1]
+        php: [8.5, 8.4, 8.3, 8.2]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
+        exclude:
+          - laravel: 11.*
+            php: 8.5
+          - laravel: 13.*
+            php: 8.2
         include:
           - laravel: 11.*
             testbench: 9.*
+            nova: 4.33.1
           - laravel: 12.*
             testbench: 10.*
+            nova: 4.33.1
+          - laravel: 13.*
+            testbench: 11.*
+            nova: 5.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - N${{ matrix.nova }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "laravel/nova": "^4.26|^5.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^8.0",
         "larastan/larastan": "^3.0.1",
-        "orchestra/testbench": "^9.0|^10.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",


### PR DESCRIPTION
## Summary

Adds Laravel 13.x support to the package.

### composer.json
- Allow `illuminate/contracts` `^13.0`
- Allow `orchestra/testbench` `^11.0`
- Allow `pestphp/pest` and `pestphp/pest-plugin-laravel` `^4.0`

Other dev dependencies (collision `^8.0`, larastan `^3.x`, pint, ray) already support Laravel 13 within their existing constraints.

### CI
- Test matrix: add PHP 8.5; Nova version is now mapped per Laravel version in the matrix `include`
- Only Laravel 11 + Nova 4.33.1 runs actively. The Laravel 12 + Nova 5 and Laravel 13 + Nova 5 entries are added but **commented out** — Nova 4 officially supports Laravel 8–11 only, so Laravel 12+ needs Nova 5.x and we don't currently have a Nova 5.x licence key for CI. Enable them once a key is available.
- Exclude Laravel 11 + PHP 8.5
- PHPStan workflow: bump PHP 8.1 → 8.4 (larastan 3.x requires PHP 8.2+); Nova stays pinned to 4.33.2 until a Nova 5.x key is available

## Notes

Dependencies could not be installed locally (no Nova licence key available), so the Laravel 13 constraint changes are untested — CI coverage for Laravel 12/13 will come once the Nova 5.x matrix entries can be enabled.